### PR TITLE
tmpl_text tag

### DIFF
--- a/tmpl.pegjs
+++ b/tmpl.pegjs
@@ -865,6 +865,7 @@ BlockTMPLTagName
   / "TMPL_SETVAR"
   / "TMPL_WITH"
   / "TMPL_WS"
+  / "TMPL_TEXT"
 
 ConditionalTagName
   = "TMPL_IF"


### PR DESCRIPTION
It's deprecated, so the warning about it is also good, but it's valid anyway
